### PR TITLE
feat: add social share buttons

### DIFF
--- a/src/_includes/components/share-buttons.njk
+++ b/src/_includes/components/share-buttons.njk
@@ -1,0 +1,30 @@
+{# Social share buttons component #}
+{%- set fullUrl = meta.url + page.url -%}
+{%- set encodedUrl = fullUrl | urlEncode -%}
+{%- set encodedTitle = title | urlEncode -%}
+<div class="flex gap-4 mt-8 mb-8">
+  {# Twitter/X share button #}
+  <a href="https://twitter.com/intent/tweet?url={{ encodedUrl }}&text={{ encodedTitle }}"
+     target="_blank"
+     rel="noopener noreferrer"
+     class="inline-flex items-center justify-center w-10 h-10 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors duration-200"
+     aria-label="Share on Twitter/X">
+    <span class="text-lg" aria-hidden="true">🐦</span>
+  </a>
+
+  {# LinkedIn share button #}
+  <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ encodedUrl }}"
+     target="_blank"
+     rel="noopener noreferrer"
+     class="inline-flex items-center justify-center w-10 h-10 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors duration-200"
+     aria-label="Share on LinkedIn">
+    <span class="text-lg" aria-hidden="true">💼</span>
+  </a>
+
+  {# Copy link button #}
+  <button onclick="navigator.clipboard.writeText(window.location.href)"
+          class="inline-flex items-center justify-center w-10 h-10 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors duration-200"
+          aria-label="Copy link">
+    <span class="text-lg" aria-hidden="true">📋</span>
+  </button>
+</div>

--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -19,9 +19,10 @@ type: article
             </small>
             <h1>{{ title }}</h1>
             {% articleLabels difficulty, contentType, technologies %}
-            {{content | safe}}
-        </article>
-        {% include "footer.njk" %}
+             {{content | safe}}
+             {% include "components/share-buttons.njk" %}
+         </article>
+         {% include "footer.njk" %}
     </body>
     <!-- End Body -->
 </html>


### PR DESCRIPTION
Add social share buttons component to blog posts

- Create src/_includes/components/share-buttons.njk with Twitter/X, LinkedIn, and copy link functionality
- Include component in article layout after content, before footer
- Use icon-only buttons with hover states and accessibility features
- URLs are properly URL-encoded for sharing
- All tests pass