### PR TITLE
fix(blog): protect inline code spans from dictionary link injection

### DIFF
--- a/scripts/process-links.js
+++ b/scripts/process-links.js
@@ -152,67 +152,115 @@ function processInternalLinks(content) {
 }
 
 /**
- * Process dictionary terms - find dictionary terms in text and wrap them
+ * Regex that matches protected zones within a line — content that should never
+ * have dictionary terms injected into it. Matches left-to-right; the first
+ * branch that wins is the one we keep verbatim.
+ *
+ * Order matters — longer/greedier patterns first:
+ *   1. Nunjucks shortcodes:  {% ... %}
+ *   2. Inline code spans:    `...`
+ *   3. Markdown links/images: [text](url) or ![alt](url)
+ *   4. Bare URLs:            https://… until whitespace
+ */
+const PROTECTED_ZONE = /\{%[^%]*%\}|`[^`]+`|!?\[[^\]]*\]\([^)]*\)|https?:\/\/\S+/g;
+
+/**
+ * Replace dictionary terms only in the plain-text segments of a line.
+ * Protected zones (code spans, URLs, shortcodes, links) are preserved verbatim.
+ */
+function replaceInPlainText(line, termRegex, replacement) {
+  // Split the line into alternating [plain, protected, plain, protected, …] segments
+  let lastIndex = 0;
+  const parts = [];
+
+  for (const match of line.matchAll(PROTECTED_ZONE)) {
+    if (match.index > lastIndex) {
+      parts.push({ text: line.slice(lastIndex, match.index), plain: true });
+    }
+    parts.push({ text: match[0], plain: false });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < line.length) {
+    parts.push({ text: line.slice(lastIndex), plain: true });
+  }
+
+  // Only replace inside plain segments
+  let replaced = false;
+  const result = parts.map(part => {
+    if (!part.plain || replaced) return part.text;
+    const after = part.text.replace(termRegex, (m) => {
+      replaced = true;
+      return replacement(m);
+    });
+    return after;
+  }).join('');
+
+  return { result, replaced };
+}
+
+/**
+ * Process dictionary terms — find dictionary terms in text and wrap them.
+ *
+ * Rules:
+ *   - Only the first occurrence of each term in the entire content gets a tooltip.
+ *   - Terms inside fenced code blocks (``` or ~~~), inline code spans, URLs,
+ *     markdown links, shortcodes, or headings are never touched.
  */
 function processDictionaryTerms(content) {
   if (!CONFIG.dictionaryDetection.enabled || dictionaryTerms.length === 0) {
     return content;
   }
-  
+
   // Sort terms by length (longest first) to avoid partial matches
   const sortedTerms = [...dictionaryTerms].sort((a, b) => b.length - a.length);
-  
+
   let processedContent = content;
-  
+
   for (const term of sortedTerms) {
     if (term.length < CONFIG.dictionaryDetection.minWordLength) {
       continue;
     }
-    
+
     if (CONFIG.dictionaryDetection.excludeWords.includes(term.toLowerCase())) {
       continue;
     }
-    
+
     // Skip if term is already wrapped in a dictionaryLink shortcode
     const existingPattern = new RegExp(`{%\\s*dictionaryLink\\s[^}]*"${term}"[^}]*%}`, 'gi');
     if (existingPattern.test(processedContent)) {
       continue;
     }
-    
-    // Create regex for the term (word boundaries to avoid partial matches)
-    const flags = CONFIG.dictionaryDetection.caseSensitive ? 'g' : 'gi';
-    const termRegex = new RegExp(`\\b${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, flags);
-    
-    // Only replace if not already inside a link or shortcode
+
+    // Build a regex that matches the term once (no g flag — we only want the first match per line)
+    const caseFlag = CONFIG.dictionaryDetection.caseSensitive ? '' : 'i';
+    const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const termRegex = new RegExp(`\\b${escapedTerm}\\b`, caseFlag);
+    const replacement = (match) => `{% dictionaryLink "${match}", "${term.toLowerCase()}" %}`;
+
     const lines = processedContent.split('\n');
     let insideCodeBlock = false;
-    
+    let found = false;
+
     const processedLines = lines.map(line => {
-      // Check for code block boundaries (triple backticks)
-      if (line.trim().startsWith('```')) {
+      // Fenced code block boundaries (``` or ~~~)
+      if (/^\s*(```|~~~)/.test(line)) {
         insideCodeBlock = !insideCodeBlock;
-        return line; // Don't process the code block delimiter itself
-      }
-      
-      // Skip lines inside code blocks
-      if (insideCodeBlock) {
         return line;
       }
-      
-      // Skip lines that already contain shortcodes, markdown links, or headers
-      if (/{%.*%}/.test(line) || /\[[^\]]*\]\([^)]*\)/.test(line) || /^\s*#{1,6}\s/.test(line)) {
+
+      // Skip lines inside code blocks, headers, or if we already placed this term
+      if (insideCodeBlock || found || /^\s*#{1,6}\s/.test(line)) {
         return line;
       }
-      
-      // Replace the term with dictionaryLink shortcode
-      return line.replace(termRegex, (match) => {
-        return `{% dictionaryLink "${match}", "${term.toLowerCase()}" %}`;
-      });
+
+      const { result, replaced } = replaceInPlainText(line, termRegex, replacement);
+      if (replaced) found = true;
+      return result;
     });
-    
+
     processedContent = processedLines.join('\n');
   }
-  
+
   return processedContent;
 }
 

--- a/src/blog/en-us/get-most-out-of-claude-code.md
+++ b/src/blog/en-us/get-most-out-of-claude-code.md
@@ -234,7 +234,7 @@ Model Context Protocol (MCP) tools extend an agent's capabilities by connecting 
 
 ### Context7: Always-Current Documentation
 
-The biggest frustration with AI coding assistants is their knowledge cutoff. It is not uncommon to reference outdated API schemas, invalid Typescript types, or obsolete library versions. {% externalLink "Context7", "https://github.com/upstash/context7" %} solves this by providing real-time access to current documentation.
+The biggest frustration with AI coding assistants is their knowledge cutoff. It is not uncommon to reference outdated {% dictionaryLink "API", "api" %} schemas, invalid Typescript types, or obsolete library versions. {% externalLink "Context7", "https://github.com/upstash/context7" %} solves this by providing real-time access to current documentation.
 
 **Why This Matters:**
 Instead of the agent suggesting deprecated AWS SDK commands, Context7 ensures the AI always references current best practices and APIs. This also eliminates searching for docs using Fetch, resulting in fewer tool calls.
@@ -324,7 +324,7 @@ The structured nature of these languages, combined with extensive documentation 
 
 ### RFC-Based and Standardized Implementations
 
-When implementing well-documented standards like OAuth 2.0, SAML, SCIM, or {% dictionaryLink "OpenAPI", "openapi" %} specifications, AI agents can quickly produce functional implementations. The extensive documentation and standardized patterns make these tasks particularly suitable for AI assistance.
+When implementing well-documented standards like {% dictionaryLink "OAuth", "oauth" %} 2.0, {% dictionaryLink "SAML", "saml" %}, {% dictionaryLink "SCIM", "scim" %}, or {% dictionaryLink "OpenAPI", "openapi" %} specifications, AI agents can quickly produce functional implementations. The extensive documentation and standardized patterns make these tasks particularly suitable for AI assistance.
 
 **Critical Caveat:** While the implementation may be functionally correct, you must personally understand the security implications of authentication and authorization code. AI agents lack the critical thinking necessary to identify subtle security vulnerabilities or implementation pitfalls that could compromise your system.
 

--- a/src/blog/en-us/opnsense-wireguard-vpn-failover.md
+++ b/src/blog/en-us/opnsense-wireguard-vpn-failover.md
@@ -50,7 +50,7 @@ We will refer to the existing tunnel as `wg1` throughout. If yours has a differe
 
 First, we need the connection details for our two fallback servers. We want to pick servers with low load in geographically close locations.
 
-IVPN publishes their server list at `https://{% dictionaryLink "api", "api" %}.ivpn.net/v5/servers.json`. Open that URL and find two WireGuard servers in your preferred locations. For each server, note down:
+IVPN publishes their server list at `https://api.ivpn.net/v5/servers.json`. Open that URL and find two WireGuard servers in your preferred locations. For each server, note down:
 
 - **Hostname** (e.g., `us-ca6.wg.ivpn.net`)
 - **Public key**

--- a/tests/unit/scripts/process-links.test.js
+++ b/tests/unit/scripts/process-links.test.js
@@ -503,15 +503,16 @@ def encrypt_data(data):
 Final encryption text.`;
       
       const result = processDictionaryTerms(input);
-      
-      // Should process terms outside all code blocks (3 occurrences)
+
+      // Should process only the first occurrence outside code blocks
       const outsideMatches = result.match(/{% dictionaryLink "encryption", "encryption" %}/g);
-      expect(outsideMatches).toHaveLength(3);
-      
+      expect(outsideMatches).toHaveLength(1);
+      expect(result).toContain('First {% dictionaryLink "encryption", "encryption" %} text.');
+
       // Should not process terms inside either code block
       const bashBlock = result.match(/```bash[\s\S]*?```/);
       const pythonBlock = result.match(/```python[\s\S]*?```/);
-      
+
       expect(bashBlock[0]).not.toContain('dictionaryLink');
       expect(pythonBlock[0]).not.toContain('dictionaryLink');
       expect(bashBlock[0]).toContain('# This encryption should not be processed');
@@ -553,10 +554,11 @@ Final encryption text.`;
       
       const result = processDictionaryTerms(input);
       
-      // Should process terms outside code blocks
+      // Should process only the first occurrence outside code blocks
       expect(result).toContain('Regular {% dictionaryLink "encryption", "encryption" %} text.');
-      expect(result).toContain('Final {% dictionaryLink "encryption", "encryption" %} text.');
-      
+      // Second occurrence outside code block should NOT be processed (first-only)
+      expect(result).toContain('Final encryption text.');
+
       // Should not process terms inside the code block
       const codeBlock = result.match(/```markdown[\s\S]*?```/);
       expect(codeBlock[0]).not.toContain('dictionaryLink');
@@ -641,10 +643,11 @@ Body text with encryption term.`;
       expect(result).not.toContain('### The Buffer Timing {% dictionaryLink');
       expect(result).not.toContain('# Main Header with {% dictionaryLink');
 
-      // Body text should still be processed
+      // Only the first body occurrence should be processed
       expect(result).toContain('Regular {% dictionaryLink "encryption", "encryption" %} text here.');
-      expect(result).toContain('More {% dictionaryLink "encryption", "encryption" %} content.');
-      expect(result).toContain('Body text with {% dictionaryLink "encryption", "encryption" %} term.');
+      // Subsequent occurrences should remain plain text
+      expect(result).toContain('More encryption content.');
+      expect(result).toContain('Body text with encryption term.');
     });
 
     it('should not process dictionary terms in h1-h6 headers', () => {
@@ -699,9 +702,10 @@ Regular #encryption hashtag should be processed.`;
       // Header should not be processed (starts line with ##)
       expect(result).toContain('## Real Header with encryption\n');
 
-      // Body text with hashtag should still process dictionary terms
+      // Only the first body occurrence should be processed
       expect(result).toContain('Body text with #hashtag and {% dictionaryLink "encryption", "encryption" %} term.');
-      expect(result).toContain('Regular #{% dictionaryLink "encryption", "encryption" %} hashtag should be processed.');
+      // Second occurrence should remain plain (first-only rule)
+      expect(result).toContain('Regular #encryption hashtag should be processed.');
     });
   });
 
@@ -840,9 +844,123 @@ You can read more about it in the {% externalLink "documentation", "https://docs
     it('should handle URLs with only opening parenthesis (malformed)', () => {
       const input = '[Malformed](https://example.com/path_(incomplete) test.';
       const result = processExternalLinks(input);
-      
+
       // Should still process correctly even with malformed parentheses
       expect(result).toContain('externalLink');
+    });
+  });
+
+  describe('Bug fixes: processDictionaryTerms edge cases', () => {
+    // Bug 1: Inline code spans are not protected
+    describe('inline code span protection', () => {
+      it('should not process dictionary terms inside inline code spans', () => {
+        const input = 'Visit `https://api.ivpn.net/v5/servers.json` for the server list.';
+        const result = processDictionaryTerms(input);
+
+        // "api" should NOT be wrapped inside backticks
+        expect(result).toContain('`https://api.ivpn.net/v5/servers.json`');
+        expect(result).not.toContain('dictionaryLink');
+      });
+
+      it('should not process terms inside inline code but should process them outside', () => {
+        const input = 'The API is at `https://api.example.com` endpoint.';
+        const result = processDictionaryTerms(input);
+
+        // "API" outside code should be processed
+        expect(result).toContain('{% dictionaryLink "API", "api" %}');
+        // "api" inside code should NOT be processed
+        expect(result).toContain('`https://api.example.com`');
+      });
+
+      it('should handle multiple inline code spans on the same line', () => {
+        const input = 'Use `encryption` and `firewall` for security.';
+        const result = processDictionaryTerms(input);
+
+        // Neither term inside backticks should be processed
+        expect(result).not.toContain('dictionaryLink');
+      });
+
+      it('should handle mixed code and plain text terms on the same line', () => {
+        const input = 'Set up encryption with `openssl enc` for your firewall.';
+        const result = processDictionaryTerms(input);
+
+        // "encryption" and "firewall" are outside backticks — should be processed
+        expect(result).toContain('{% dictionaryLink "encryption", "encryption" %}');
+        expect(result).toContain('{% dictionaryLink "firewall", "firewall" %}');
+        // "enc" inside backticks should not be touched
+        expect(result).toContain('`openssl enc`');
+      });
+    });
+
+    // Bug 2: Entire line skipped if any shortcode or markdown link exists
+    describe('mixed content lines', () => {
+      it('should process dictionary terms on a line that also has a markdown link', () => {
+        const input = 'Read the [docs](https://example.com) about encryption basics.';
+        const result = processDictionaryTerms(input);
+
+        // "encryption" should still be processed even though the line has a markdown link
+        expect(result).toContain('{% dictionaryLink "encryption", "encryption" %}');
+      });
+
+      it('should process dictionary terms on a line that already has a shortcode', () => {
+        const input = 'Open {% dictionaryLink "VPN", "vpn" %} settings and configure the firewall.';
+        const result = processDictionaryTerms(input);
+
+        // "firewall" should be processed even though the line already has a shortcode
+        expect(result).toContain('{% dictionaryLink "firewall", "firewall" %}');
+      });
+    });
+
+    // Bug 3: Terms inside bare URLs in plain text
+    describe('bare URL protection', () => {
+      it('should not process terms that are part of a bare URL', () => {
+        const input = 'Visit https://api.example.com for more info about encryption.';
+        const result = processDictionaryTerms(input);
+
+        // "api" inside URL should NOT be processed
+        expect(result).toContain('https://api.example.com');
+        expect(result).not.toContain('https://{% dictionaryLink');
+        // "encryption" outside URL should be processed
+        expect(result).toContain('{% dictionaryLink "encryption", "encryption" %}');
+      });
+    });
+
+    // Bug 4: Tilde-fenced code blocks not handled
+    describe('tilde-fenced code blocks', () => {
+      it('should not process dictionary terms inside tilde-fenced code blocks', () => {
+        const input = `Text with encryption.
+
+~~~bash
+echo "encryption test"
+~~~
+
+More encryption text.`;
+
+        const result = processDictionaryTerms(input);
+
+        // First occurrence outside code block should be processed
+        expect(result).toContain('Text with {% dictionaryLink "encryption", "encryption" %}.');
+        // Second occurrence outside code block should NOT (first-only)
+        expect(result).toContain('More encryption text.');
+        // Inside tilde code block should NOT be processed
+        expect(result).toContain('echo "encryption test"');
+        expect(result).not.toContain('echo "{% dictionaryLink');
+      });
+    });
+
+    // Bug 5: Only first occurrence should get a tooltip (not all on one line)
+    describe('first occurrence only', () => {
+      it('should only wrap the first occurrence of a term, not every occurrence', () => {
+        const input = `Encryption is important.
+
+Use encryption for everything. Encryption protects your data.`;
+
+        const result = processDictionaryTerms(input);
+
+        // Count occurrences — should be exactly 1
+        const matches = result.match(/dictionaryLink/g) || [];
+        expect(matches).toHaveLength(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Refactors processDictionaryTerms to use segment-based parsing so dictionary tooltips are never injected inside inline code spans, bare URLs, or existing shortcodes.