### PR TITLE
Void Canonicalization: How an Empty String Unlocks Any SAML Identity

### DIFF
--- a/src/_data/dictionary.js
+++ b/src/_data/dictionary.js
@@ -213,5 +213,20 @@ export default {
     "en-us": "Model Context Protocol · An open standard by Anthropic that enables AI applications to securely connect to external data sources and tools. MCP provides a standardized way for AI models to access databases, APIs, and local resources through server implementations.",
     "el": "Model Context Protocol · Ένα ανοιχτό πρότυπο από την Anthropic που επιτρέπει στις AI εφαρμογές να συνδέονται με ασφάλεια σε εξωτερικές πηγές δεδομένων και εργαλεία. Το MCP παρέχει έναν τυποποιημένο τρόπο για τα AI μοντέλα να έχουν πρόσβαση σε βάσεις δεδομένων, APIs και τοπικούς πόρους μέσω υλοποιήσεων διακομιστή.",
     "tr": "Model Bağlam Protokolü · AI uygulamalarının harici veri kaynaklarına ve araçlarına güvenli bir şekilde bağlanmasını sağlayan Anthropic tarafından geliştirilen açık standart. MCP, AI modellerinin sunucu uygulamaları aracılığıyla veritabanlarına, API'lere ve yerel kaynaklara erişmesi için standartlaştırılmış bir yol sağlar."
+  },
+  "xml-canonicalization": {
+    "en-us": "The process of converting an XML document into a standardized byte sequence by normalizing attribute order, whitespace, and namespace declarations. Canonicalization (C14N) ensures two logically identical XML documents produce identical output, making cryptographic signatures over XML reliable.",
+    "el": "Η διαδικασία μετατροπής ενός εγγράφου XML σε τυποποιημένη ακολουθία bytes με κανονικοποίηση της σειράς χαρακτηριστικών, των κενών και των δηλώσεων namespace. Η κανονικοποίηση (C14N) εξασφαλίζει ότι δύο λογικά πανομοιότυπα έγγραφα XML παράγουν πανομοιότυπη έξοδο, κάνοντας αξιόπιστες τις κρυπτογραφικές υπογραφές σε XML.",
+    "tr": "Bir XML belgesini öznitelik sırası, boşluk ve ad alanı bildirimlerini normalleştirerek standartlaştırılmış bir bayt dizisine dönüştürme işlemi. Kanonikleştirme (C14N), mantıksal olarak aynı iki XML belgesinin aynı çıktıyı üretmesini sağlayarak XML üzerindeki kriptografik imzaları güvenilir kılar."
+  },
+  "parser-differential": {
+    "en-us": "An attack class that exploits the fact that two different XML parsers processing the same document can construct different logical trees. When one parser is used for security verification and another for reading data, an attacker can craft input that passes the security check while the data parser reads attacker-controlled content.",
+    "el": "Μια κατηγορία επίθεσης που εκμεταλλεύεται το γεγονός ότι δύο διαφορετικοί XML parsers που επεξεργάζονται το ίδιο έγγραφο μπορούν να κατασκευάσουν διαφορετικά λογικά δένδρα. Όταν ένας parser χρησιμοποιείται για επαλήθευση ασφάλειας και άλλος για ανάγνωση δεδομένων, ένας επιτιθέμενος μπορεί να δημιουργήσει input που περνά τον έλεγχο ασφάλειας ενώ ο parser δεδομένων διαβάζει περιεχόμενο ελεγχόμενο από τον επιτιθέμενο.",
+    "tr": "Aynı belgeyi işleyen iki farklı XML ayrıştırıcısının farklı mantıksal ağaçlar oluşturabileceği gerçeğini kullanan bir saldırı sınıfı. Güvenlik doğrulaması için bir ayrıştırıcı, veri okuma için başka bir ayrıştırıcı kullanıldığında, saldırgan güvenlik kontrolünü geçerken veri ayrıştırıcısının saldırganın kontrolündeki içeriği okuduğu bir girdi oluşturabilir."
+  },
+  "identity-provider": {
+    "en-us": "A system that authenticates users and issues identity assertions to other applications. In SAML and SSO flows, the Identity Provider (IdP) holds user credentials, signs assertions about who the user is, and vouches for their identity to Service Providers that trust the IdP's public key.",
+    "el": "Ένα σύστημα που επαληθεύει χρήστες και εκδίδει ισχυρισμούς ταυτότητας σε άλλες εφαρμογές. Στις ροές SAML και SSO, ο Identity Provider (IdP) κατέχει τα διαπιστευτήρια χρηστών, υπογράφει ισχυρισμούς για το ποιος είναι ο χρήστης και εγγυάται την ταυτότητά τους σε Service Providers που εμπιστεύονται το δημόσιο κλειδί του IdP.",
+    "tr": "Kullanıcıların kimliğini doğrulayan ve diğer uygulamalara kimlik onayları veren bir sistem. SAML ve SSO akışlarında, Kimlik Sağlayıcı (IdP) kullanıcı kimlik bilgilerini tutar, kullanıcının kim olduğuna dair onayları imzalar ve IdP'nin ortak anahtarına güvenen Hizmet Sağlayıcılara kimliğini garanti eder."
   }
 };

--- a/src/blog/en-us/void-canonicalization-how-an-empty-string-unlocks-any-saml-identity.md
+++ b/src/blog/en-us/void-canonicalization-how-an-empty-string-unlocks-any-saml-identity.md
@@ -1,0 +1,202 @@
+---
+layout: article.njk
+title: "Void Canonicalization: How an Empty String Unlocks Any SAML Identity"
+description: "When libxml2 silently returns an empty string on malformed XML, SHA-256 of nothing becomes a skeleton key for SAML authentication. A deep dive into CVE-2025-66568 and the parser differential class."
+date: 2026-04-26
+keywords: ["SAML signature bypass", "XML canonicalization vulnerability", "libxml2 empty string", "CVE-2025-66567", "CVE-2025-66568", "SAMLStorm CVE-2025-29775", "ruby-saml exploit", "parser differential attack", "void canonicalization"]
+tags: ["security", "saml", "xml", "authentication", "cve", "ruby", "nodejs", "parser-differential"]
+difficulty: expert
+contentType: deep-dive
+technologies: ["ruby-saml", "libxml2", "xml-crypto"]
+type: article
+locale: en-us
+permalink: /blog/en-us/void-canonicalization-how-an-empty-string-unlocks-any-saml-identity/
+---
+
+> **TL;DR** — libxml2's C14N function silently returns `""` on malformed XML. ruby-saml hashes that empty string without checking, producing a fixed, publicly known SHA-256 constant. One valid IdP-signed response is enough to forge a reusable signature that passes verification against any account on any affected Service Provider. Fix: ruby-saml ≥ 1.18.0 (CVE-2025-66568 / CVE-2025-66567). Node.js stacks: xml-crypto ≥ 6.0.1 (CVE-2025-29775).
+
+## Contents
+
+- [The math that shouldn't matter](#the-math-that-shouldnt-matter)
+- [How SAML builds a trust chain](#how-saml-builds-a-trust-chain)
+- [The dual-parser design decision](#the-dual-parser-design-decision)
+- [The void: when canonicalization returns nothing](#the-void-when-canonicalization-returns-nothing)
+- [Four steps from observer to administrator](#four-steps-from-observer-to-administrator)
+- [SAMLStorm and the broader class](#samlstorm-and-the-broader-class)
+- [What to do now](#what-to-do-now)
+
+---
+
+## The math that shouldn't matter
+
+Every SHA-256 implementation, on every machine, agrees on one thing:
+
+```
+SHA-256("") = e3b0c44298fc1c149afbf4c8996fb924
+              27ae41e4649b934ca495991b7852b855
+```
+
+This value is published in test vectors. It appears in every cryptography textbook that covers SHA-256. It is not a secret, and there is no expectation that it ever could be.
+
+None of that is a problem — ordinarily. The hash of empty input is only dangerous when a signature verification library can be tricked into computing and later accepting a signature over nothing. When that happens, this constant becomes a skeleton key: one RSA signature, permanently reusable, valid against any {% dictionaryLink "Service Provider", "saml" %} running the affected library.
+
+That is exactly what CVE-2025-66568 enabled in ruby-saml before version 1.18.0. It is why {% externalLink "Zakhar Fedotkin's research at Black Hat EU 2025", "https://portswigger.net/research/the-fragile-lock" %}, presented under the title "The Fragile Lock," demonstrated a complete authentication bypass against GitLab EE 17.8.4; a full account takeover with no stolen credentials and no brute force.
+
+---
+
+## How SAML builds a trust chain
+
+When your application receives a {% dictionaryLink "SAML", "saml" %} assertion — "this is alice@corp.com, she has the admin role" — it validates the XML Digital Signature attached to that document. The {% externalLink "W3C XMLDSig specification", "https://www.w3.org/TR/xmldsig-core/" %} mandates three steps, in order:
+
+1. **Canonicalize** the signed XML subtree using the algorithm declared in `<CanonicalizationMethod>`
+2. **Hash** the canonical bytes, producing a `DigestValue`
+3. **Verify** the RSA signature in `<SignatureValue>` against that digest, using the {% dictionaryLink "Identity Provider", "identity-provider" %}'s public key
+
+Step one exists because XML has no single canonical serialization. Two parties can represent the same logical document with different whitespace, different namespace prefix ordering, or different attribute quoting — and arrive at different byte sequences. {% dictionaryLink "XML canonicalization", "xml-canonicalization" %} normalizes this variance before hashing, ensuring both the issuer and verifier compute identical bytes from the same logical content.
+
+The {% externalLink "W3C Canonical XML 1.0 specification", "https://www.w3.org/TR/xml-c14n/" %} was finalized in 2001. The security community absorbed it as solved infrastructure. You call the C14N function, it returns normalized bytes, you hash them; the problem is treated as plumbing. That trust — trusted, unverified — is where this attack lives.
+
+---
+
+## The dual-parser design decision
+
+{% externalLink "ruby-saml", "https://github.com/SAML-Toolkits/ruby-saml" %}, the dominant Ruby library for SAML SSO integration, made a pragmatic architectural choice: use **Nokogiri** — a Ruby binding for libxml2, the fast C XML library — for canonicalization, and use **REXML** — Ruby's standard-library pure-Ruby XML parser — for reading the assertion's fields after validation.
+
+The rationale is not unreasonable. REXML is slow on large XML documents; libxml2 is substantially faster. When you have a performance-critical step like C14N, you reach for the C library. After validation is complete, REXML is convenient for traversing the assertion's attribute tree. Both parsers were assumed to agree on document structure; they were, after all, processing the same bytes.
+
+But "same bytes" does not mean "same parse tree." Two independent parsers can construct different logical trees from the same input · and if the input is crafted carefully, those trees can diverge in exactly the ways an attacker needs.
+
+Nobody thought to ask: what happens if they disagree about which elements exist?
+
+---
+
+## The void: when canonicalization returns nothing
+
+Fedotkin's research identified the specific failure mode: **when libxml2's C14N function encounters certain malformed XML structures in the `<ds:SignedInfo>` block, it returns an empty byte string rather than raising an error.** No exception. No non-zero return code. Silent success delivering `""`.
+
+ruby-saml, trusting the canonicalization output without checking its length, proceeds to compute:
+
+```
+canonicalize(malformed SignedInfo) → ""
+SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+The library then verifies the RSA signature in `<SignatureValue>` against this digest. An attacker who has previously obtained a valid RSA signature over SHA-256("") — obtainable from any prior SAML interaction that also triggers the empty-output path — passes this check. Every time. Against any target. Fedotkin named this class **void canonicalization**.
+
+This behaviour is assigned {% externalLink "CVE-2025-66568", "https://nvd.nist.gov/vuln/detail/CVE-2025-66568" %} (the libxml2 empty-string flaw) and CVE-2025-66567 (the broader parser differential enabling it). Both carry a CVSS 9.3 Critical rating and affect all ruby-saml versions prior to 1.18.0.
+
+The root of the specification gap is worth naming. The {% externalLink "W3C Canonical XML specification", "https://www.w3.org/TR/xml-c14n/" %} defines what a conforming C14N implementation must produce for valid, well-formed input. It does not specify mandatory error-signaling behaviour for malformed or unexpected input. In 2001, the threat model for XML Digital Signatures did not contemplate applications that would run two independent parsers over the same document within a single verification pass. libxml2's choice to return `""` was consistent with the spec — and catastrophic in context.
+
+---
+
+## Four steps from observer to administrator
+
+To understand why this is exploitable, you need to see the two parsers as an attacker does: they are a seam between *what gets signed* and *what gets read*.
+
+A void canonicalization attack constructs a SAML response where the `<ds:SignedInfo>` block is malformed in a way that causes libxml2 to produce empty output, while a forged `<saml:Assertion>` is embedded in a position that REXML traverses and reads correctly, but that libxml2's C14N silently skips:
+
+```xml
+<samlp:Response ...>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <!-- Malformed structure: triggers libxml2 to return "" from C14N -->
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+      <ds:Reference URI="#forged">...</ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+      <!-- Precomputed RSA signature over SHA-256("") -->
+    </ds:SignatureValue>
+  </ds:Signature>
+
+  <!-- Forged Assertion: namespace REXML reads, libxml2 C14N skips -->
+  <saml:Assertion ID="forged">
+    <saml:Subject>
+      <saml:NameID>admin@target.com</saml:NameID>
+    </saml:Subject>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="role">
+        <saml:AttributeValue>administrator</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>
+```
+
+The verification path through ruby-saml:
+
+```mermaid
+sequenceDiagram
+    participant A as Attacker
+    participant SP as Service Provider (ruby-saml)
+    participant N as Nokogiri / libxml2
+    participant R as REXML
+
+    A->>SP: POST forged SAML Response
+    SP->>N: canonicalize(malformed SignedInfo)
+    N-->>SP: "" (no error raised)
+    SP->>SP: SHA-256("") = e3b0c44...
+    SP->>SP: verify RSA signature over e3b0c44... ✓
+    SP->>R: parse Assertion for identity claims
+    R-->>SP: NameID=admin@target.com · role=administrator
+    SP-->>A: session created as administrator
+```
+
+The attacker does not break RSA. They do not steal the IdP's private key. They do not intercept a live session. They need exactly one thing: **a valid RSA signature over SHA-256("")**. That signature is reusable against every account on every Service Provider running the unpatched library; it is as close to a universal skeleton key as the authentication layer can produce.
+
+---
+
+## SAMLStorm and the broader class
+
+Void canonicalization is not an isolated bug; it is an instance of a structural attack class.
+
+In the Node.js ecosystem, **SAMLStorm** (CVE-2025-29775) exploited a different mechanism in xml-crypto: an attacker could inject XML comments inside a `<DigestValue>` element in a way that the canonicalization component ignored but the assertion-reading component preserved, causing the two components to construct different views of the signed scope. The mechanisms differ; the architecture is identical.
+
+The generalizable pattern is {% dictionaryLink "parser differential", "parser-differential" %}: two parsers process the same byte sequence, produce different logical trees, and the application trusts them for different purposes. One tree handles the security decision — signature valid or not. A different tree extracts the claims the application acts on. An attacker who can control the divergence between those trees can make the security decision pass while the claim tree contains arbitrary content.
+
+The W3C XMLDSig specification, written in 2001, did not contemplate this architecture. It specified what correct C14N implementations must produce for valid input. It could not specify how every future implementation would compose canonicalization with assertion reading — whether through a single parse tree or through two independent parsers separated by a performance optimization decision made years later.
+
+This is worth sitting with. The spec solved the normalization problem cleanly. The vulnerability is not in the spec. It emerged from an architectural pattern the spec never modelled; an absence of a rule in a 2001 document became the attack surface in a 2025 CVE.
+
+---
+
+## What to do now
+
+**Patch immediately.** ruby-saml 1.18.0 treats an empty string returned from canonicalization as a hard validation failure. The empty output is no longer silently accepted as input to the hash step. For Node.js stacks: xml-crypto ≥ 6.0.1 addresses CVE-2025-29775, with backports to 3.2.1 and 2.1.6.
+
+> **Note:** If you are running ruby-saml < 1.17.0, you are also exposed to CVE-2025-25291 and CVE-2025-25292, earlier parser differential flaws in the same library. Update directly to 1.18.0.
+
+**Audit any SAML library in your stack.** Ask two questions:
+
+1. Does the library use a C library such as libxml2 for canonicalization and a separate parser for assertion reading?
+2. Does it validate that the canonicalization output is non-empty before computing the digest?
+
+If the answer to (1) is yes and (2) is no, treat the library as unpatched regardless of the version number.
+
+**Test your validation path.** Burp Suite's SAML Raider extension can send a SAML response with a stripped or malformed `<ds:SignedInfo>` block. Submit it to your Service Provider and verify the application returns a hard authentication failure, not a session. If it accepts the malformed response, your stack is vulnerable. This test belongs in the security regression suite for any SSO-integrated service.
+
+---
+
+## The structural lesson
+
+Standards solve the problems they were designed to solve. They do not solve the implementation failure modes that arise when those standards are embedded in architectures the spec authors never modelled.
+
+XML canonicalization has been "solved" since 2001. The spec is precise, well-tested, and deployed across thousands of systems. None of that prevented CVE-2025-66568. The spec's silence on malformed-input error signalling became a vulnerability when libxml2 returned `""` instead of raising, and when SAML libraries optimized their pipelines by routing the same document through two independent parsers without asking whether those parsers could disagree.
+
+There is a name for what happened in the verification path: a **vacuous proof**. The library proved the signature was valid over a canonical form that contained nothing · and therefore proved nothing about the document the application would read next. But the check returned `true`, and a session was created.
+
+The correctable principle is narrow and specific: any transformation step in a security-critical pipeline that can silently return empty or minimal output must validate its output length before the downstream step acts on it. This is not paranoia. It is the same discipline you apply to input validation at system boundaries, applied one layer deeper, at the transformation layer.
+
+The plumbing nobody audits is exactly where attackers look.
+
+---
+
+## References
+
+- Fedotkin, Z. (2025, December). *The Fragile Lock: Novel Bypasses for SAML Authentication*. Black Hat EU 2025. [https://portswigger.net/research/the-fragile-lock](https://portswigger.net/research/the-fragile-lock)
+- NVD. *CVE-2025-66568*. [https://nvd.nist.gov/vuln/detail/CVE-2025-66568](https://nvd.nist.gov/vuln/detail/CVE-2025-66568)
+- NVD. *CVE-2025-66567*. [https://nvd.nist.gov/vuln/detail/CVE-2025-66567](https://nvd.nist.gov/vuln/detail/CVE-2025-66567)
+- NVD. *CVE-2025-29775 (SAMLStorm)*. [https://nvd.nist.gov/vuln/detail/CVE-2025-29775](https://nvd.nist.gov/vuln/detail/CVE-2025-29775)
+- W3C. (2001). *Canonical XML Version 1.0*. [https://www.w3.org/TR/xml-c14n/](https://www.w3.org/TR/xml-c14n/)
+- W3C. (2008). *XML Signature Syntax and Processing (Second Edition)*. [https://www.w3.org/TR/xmldsig-core/](https://www.w3.org/TR/xmldsig-core/)
+- SAML-Toolkits. *ruby-saml releases*. [https://github.com/SAML-Toolkits/ruby-saml/releases](https://github.com/SAML-Toolkits/ruby-saml/releases)
+- node-saml. *xml-crypto security advisory*. [https://github.com/node-saml/xml-crypto](https://github.com/node-saml/xml-crypto)

--- a/src/blog/en-us/void-canonicalization-how-an-empty-string-unlocks-any-saml-identity.md
+++ b/src/blog/en-us/void-canonicalization-how-an-empty-string-unlocks-any-saml-identity.md
@@ -31,7 +31,7 @@ permalink: /blog/en-us/void-canonicalization-how-an-empty-string-unlocks-any-sam
 
 Every SHA-256 implementation, on every machine, agrees on one thing:
 
-```
+```text
 SHA-256("") = e3b0c44298fc1c149afbf4c8996fb924
               27ae41e4649b934ca495991b7852b855
 ```
@@ -76,7 +76,7 @@ Fedotkin's research identified the specific failure mode: **when libxml2's C14N 
 
 ruby-saml, trusting the canonicalization output without checking its length, proceeds to compute:
 
-```
+```text
 canonicalize(malformed SignedInfo) → ""
 SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```


### PR DESCRIPTION
# PR: Void Canonicalization — SAML Authentication Bypass Deep Dive

## Summary

- Adds new expert-level **Explanation** post on void canonicalization (CVE-2025-66568 / CVE-2025-66567) in ruby-saml, covering how libxml2's silent empty-string return from C14N turns SHA-256("") into a reusable skeleton key for SAML identity bypass.
- Covers the broader **parser differential** class, including SAMLStorm (CVE-2025-29775 in xml-crypto / Node.js).
- Adds three new dictionary entries: `xml-canonicalization`, `parser-differential`, `identity-provider`.

## Claim verification notes

All key factual claims were verified via web search and source fetching before drafting:

| Claim | Verified | Notes |
|---|---|---|
| CVE-2025-66568 = libxml2 empty-string void canonicalization | ✓ | NVD confirmed, CVSS 9.3 Critical |
| CVE-2025-66567 = parser differential (REXML vs Nokogiri) | ✓ | NVD confirmed, same patch |
| ruby-saml ≥ 1.18.0 patches both CVEs | ✓ | GitHub advisory GHSA-x4h9-gwv3-r4m4 |
| CVE-2025-29775 = SAMLStorm in xml-crypto | ✓ | NVD confirmed, CVSS 9.3 Critical |
| SAMLStorm fixed in xml-crypto 6.0.1 / 3.2.1 / 2.1.6 | ✓ | GitHub advisory GHSA-x3m8-899r-f7c3 |
| Research by Zakhar Fedotkin (PortSwigger), Black Hat EU 2025 | ✓ | Confirmed via portswigger.net/research/the-fragile-lock |
| Demo platform was GitLab EE 17.8.4 | ✓ | Confirmed via PortSwigger page (seed said "unnamed SaaS") |
| SHA-256("") = e3b0c44... | ✓ | Cryptographic constant, NIST FIPS 180-4 test vectors |
| W3C C14N spec finalized 2001 | ✓ | https://www.w3.org/TR/xml-c14n/ |

One seed correction applied: the raw source described the PortSwigger demo as happening against "an unnamed SaaS platform." The PortSwigger research page names it as **GitLab EE 17.8.4**. The post uses the verified, named platform.

## Structure

- **Diataxis**: Explanation (understanding-oriented, discursive, connects to broader class, admits opinion)
- **Length**: ~2,050 words prose + code blocks, within 1,800–2,500 target band
- **TOC**: yes (>1,500 words)
- **TL;DR**: yes (blockquote at top)
- **Code blocks**: SHA-256("") constant; malformed SignedInfo XML sketch
- **Mermaid diagram**: sequence diagram of attack flow through ruby-saml's dual-parser path
- **H2 sections**: 7 (The math / Trust chain / Dual-parser / The void / Four steps / SAMLStorm class / What to do + structural lesson closing)
- **Dictionary links**: `saml` (existing), `xml-canonicalization` (new), `identity-provider` (new), `parser-differential` (new)
- **External links**: PortSwigger "The Fragile Lock", W3C XMLDSig spec, W3C C14N spec, ruby-saml GitHub, NVD CVE-2025-66568

## What reviewers should check

1. **GitLab version**: Post states the demo was on GitLab EE 17.8.4 — verify this matches the published PortSwigger page at https://portswigger.net/research/the-fragile-lock before merging.
2. **CVE numbers**: CVE-2025-66567 and CVE-2025-66568 are confirmed, but double-check that NVD has them fully populated with descriptions (they may have been under embargo near the December 2025 disclosure date).
3. **ruby-saml patch version**: Confirmed as 1.18.0. Earlier parser differential CVEs (CVE-2025-25291 / CVE-2025-25292) affected < 1.17.0 — the post correctly distinguishes these in the Note callout.
4. **SAMLStorm mechanism**: The post accurately distinguishes SAMLStorm's DigestValue comment injection from void canonicalization's empty-string C14N path — both are parser differential but different exploits. Verify this framing is accurate with the xml-crypto advisory.
5. **Dictionary definitions**: Three new entries added. Check that the Greek (el) and Turkish (tr) translations are idiomatic — they follow the same templates as existing entries but should be reviewed by a native speaker if possible.
6. **Mermaid diagram**: Verify the diagram renders in the 11ty build. The existing `curl-bash-pipe-security.md` post uses mermaid, so the pipeline should support it.


---

<sub>blog-drafter run bd-mog7sjo8-1t6sma · ai_repo_sha: 24e5e1d4a3553a444162cbf3780ff0c42efe5b9d · claude_job de39df4f-ab7c-4787-87b6-053934e37853</sub>
