### PR TITLE
chore(beads): disable auto-export

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -55,3 +55,5 @@
 
 sync.remote: "git+https://github.com/aris1009/aris1009.github.io.git"
 export.git-add: false
+
+export.auto: false


### PR DESCRIPTION
bd writes go directly to anvil; the local issues.jsonl export is redundant.

Refs: selfhosted-cujs.1